### PR TITLE
Wrap logged-out home page view.

### DIFF
--- a/src/scripts/components/BrandHeader.tsx
+++ b/src/scripts/components/BrandHeader.tsx
@@ -6,7 +6,7 @@ interface BrandHeaderProps {
 }
 
 const BrandHeader = (props: BrandHeaderProps) => {
-  return <section className="brand-header page-section">
+  return <section className="brand-header page-section page-section--tall">
 
     <div className="container">
       <div className="brand-header__grid">

--- a/src/scripts/components/ProductCardCarousel.tsx
+++ b/src/scripts/components/ProductCardCarousel.tsx
@@ -1,16 +1,33 @@
+import { useRef } from "preact/hooks"
+import { DisableCopyComponent } from "../lib/interfaces"
+import Button from "./Button"
 import CardCarouselBackgroundSVG from "./CardCarouselBackgroundSVG"
 import { Card } from "./Cards"
 import Carousel, { CarouselProps } from "./Carousel"
+import CopyComponent from "./CopyComponent"
 
-interface ProductCardCarouselProps {
+interface ProductCardCarouselProps extends DisableCopyComponent {
+  title?: string,
+  titleLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  subtitle?: string,
+  collectionLink?: string,
+  collectionLinkText?: string,
 }
 
 const ProductCardCarousel = (props: ProductCardCarouselProps) => {
+
+  const ViewMoreLink = () => props.collectionLink && props.collectionLinkText ? (
+    <Button disableCopy className="product-cards-carousel__view-more" component="a" href={props.collectionLink} variant={'link'}>
+      {props.collectionLinkText}
+    </Button>
+  ) : null
 
   const carouselProps: CarouselProps = {
     pagination: (
       <div className="product-cards-carousel__pagination">
         <ul className="splide__pagination"></ul>
+
+        <ViewMoreLink />
       </div>
     ),
     splideProps: {
@@ -39,11 +56,27 @@ const ProductCardCarousel = (props: ProductCardCarouselProps) => {
     }
   }
 
-  return <div className="product-cards-carousel">
+  const TitleTag = props.titleLevel || 'h2'
+
+  const elementRef = useRef(null)
+  const elements = <div className="product-cards-carousel" ref={elementRef}>
     <div className="product-cards-carousel__bg">
       <CardCarouselBackgroundSVG />
     </div>
+
     <div className="container">
+      <div className="product-cards-carousel__header">
+        <div className="product-cards-carousel__header-left">
+          <TitleTag className="product-cards-carousel__title typography-heading-md">{props.title}</TitleTag>
+          <p className="product-cards-carousel__subtitle typography-body-sm">{props.subtitle}</p>
+        </div>
+
+        {props.collectionLink && props.collectionLinkText ? (
+          <div className="product-cards-carousel__header-right">
+            <ViewMoreLink />
+          </div>) : null}
+      </div>
+
       <Carousel {...carouselProps}>
         <Card disableCopy title='Magic Cards Set' priceRetail={2999} priceWholeSale={1999} />
         <Card disableCopy title='The Vault Set' priceRetail={2999} priceWholeSale={1999} />
@@ -54,6 +87,11 @@ const ProductCardCarousel = (props: ProductCardCarouselProps) => {
       </Carousel>
     </div>
   </div>
+
+  return props.disableCopy ? elements : (<div className="relative">
+    <CopyComponent onClick={() => navigator.clipboard.writeText(elementRef.current.outerHTML)} />
+    {elements}
+  </div>)
 }
 
 export default ProductCardCarousel

--- a/src/scripts/pages/Home.tsx
+++ b/src/scripts/pages/Home.tsx
@@ -61,7 +61,7 @@ export default function Home() {
           collectionLinkText="Peek New Arrivals"
         />
         <TextImageSplit order="image-first" />
-        <CalloutGrid />
+        <CalloutGrid title="Popular Collections" />
         <Hero
           title="Our Beginner Magic Collection"
           description="Every trick has a strong start — and so do all great magicians. Enter the world of curiosity with our collection of best-selling Beginner Magic."

--- a/src/scripts/pages/Home.tsx
+++ b/src/scripts/pages/Home.tsx
@@ -9,6 +9,11 @@ import LogoMarquee from "../components/LogoMarquee";
 
 // Asset imports
 import ArtOfUnknown from "../../images/icons/ico-art-of-unknown.svg";
+import Carousel from "../components/Carousel";
+import { Tag } from "../components/Tags";
+import Button from "../components/Button";
+
+import { heroCarouselOne, heroMobileCarouselOne } from "../assets/hero-images";
 
 export default function Home() {
   return (
@@ -16,6 +21,37 @@ export default function Home() {
       <Header />
 
       <main role="main">
+        <Carousel className="hero-carousel">
+          <Hero
+            style="dark"
+            alignment="left"
+            title="Apprentice Magic"
+            description={null}
+            mobileLayout="stacked"
+            hasBackground
+            image={
+              <img src={heroCarouselOne.src} srcSet={heroCarouselOne.srcSet} alt="Apprentice Magic" width={3978} height={1620} />
+            }
+            mobileImage={
+              <img src={heroMobileCarouselOne.src} alt="Apprentice Magic" width={722} height={709} />
+            }
+            tags={
+              <Tag showDecorations disableCopy component="span" variant="label secondary-invert">Trending Now</Tag>
+            }
+            buttons={
+              <Button disableCopy component="a" href="#" variant={'primary'}>View Product</Button>
+            }
+          />
+          <Hero
+            style="dark"
+            alignment="left"
+            title="Anverdi Magic"
+            description={null}
+            buttons={
+              <Button disableCopy component="a" href="#" variant={'primary'}>View Product</Button>
+            }
+          ></Hero>
+        </Carousel>
         <BrandHeader />
         <TextImageSplit order="image-first" />
         <CalloutGrid />

--- a/src/scripts/pages/Home.tsx
+++ b/src/scripts/pages/Home.tsx
@@ -14,6 +14,7 @@ import { Tag } from "../components/Tags";
 import Button from "../components/Button";
 
 import { heroCarouselOne, heroMobileCarouselOne } from "../assets/hero-images";
+import ProductCardCarousel from "../components/ProductCardCarousel";
 
 export default function Home() {
   return (
@@ -53,6 +54,12 @@ export default function Home() {
           ></Hero>
         </Carousel>
         <BrandHeader />
+        <ProductCardCarousel
+          title="Check out the latest drop"
+          subtitle="New magic that thrills"
+          collectionLink="#"
+          collectionLinkText="Peek New Arrivals"
+        />
         <TextImageSplit order="image-first" />
         <CalloutGrid />
         <Hero

--- a/src/styles/components/product-card-carousel.css
+++ b/src/styles/components/product-card-carousel.css
@@ -6,17 +6,31 @@
 }
 
 .product-cards-carousel__bg {
+  pointer-events: none;
   position: absolute;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
-  
+
   svg {
-    opacity: .2;
+    opacity: 0.2;
     width: 100%;
     height: 100%;
   }
+}
+
+.product-cards-carousel__header {
+  margin-bottom: 2rem;
+}
+
+.product-cards-carousel__header-right {
+  display: none;
+}
+
+.product-cards-carousel__title {
+  margin-bottom: 0.75rem;
+  line-height: 1;
 }
 
 .product-cards-carousel .splide__track {
@@ -30,6 +44,11 @@
 
 .product-cards-carousel__pagination {
   padding: 1rem 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-content: center;
+  align-items: center;
 
   .splide__pagination {
     justify-content: flex-start;
@@ -39,7 +58,29 @@
     border-color: var(--color-primary-midnight);
   }
 
+  .splide__pagination__page:not(.is-active):hover::before,
+  .splide__pagination__page:not(.is-active):focus-visible::before {
+    border-color: var(--color-secondary-water);
+  }
+
   .splide__pagination__page.is-active::before {
     background-color: var(--color-primary-midnight);
+  }
+}
+
+@media (min-width: 640px) {
+  .product-cards-carousel__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    align-content: flex-end;
+  }
+
+  .product-cards-carousel__pagination .product-cards-carousel__view-more {
+    display: none;
+  }
+
+  .product-cards-carousel__header-right {
+    display: block;
   }
 }


### PR DESCRIPTION
- Taller BrandHeader section padding
- Support for title/subtitle/view more link on carousel
- Add card carousel to logged out view.
- Add missing title to callout
